### PR TITLE
Check same-head function comparison before unfolding

### DIFF
--- a/base/src/main/java/org/arend/core/expr/visitor/CompareVisitor.java
+++ b/base/src/main/java/org/arend/core/expr/visitor/CompareVisitor.java
@@ -19,6 +19,7 @@ import org.arend.core.sort.SortExpression;
 import org.arend.core.subst.*;
 import org.arend.ext.core.level.LevelSubstitution;
 import org.arend.ext.core.definition.CoreFunctionDefinition;
+import org.arend.ext.core.expr.CoreExpression;
 import org.arend.ext.core.ops.CMP;
 import org.arend.ext.core.ops.NormalizationMode;
 import org.arend.prelude.Prelude;
@@ -26,6 +27,7 @@ import org.arend.term.concrete.Concrete;
 import org.arend.typechecking.TypecheckerState;
 import org.arend.typechecking.implicitargs.equations.DummyEquations;
 import org.arend.typechecking.implicitargs.equations.Equations;
+import org.arend.typechecking.visitor.SearchVisitor;
 import org.arend.ext.util.Pair;
 import org.jetbrains.annotations.TestOnly;
 
@@ -44,6 +46,7 @@ public class CompareVisitor implements ExpressionVisitor2<Expression, Expression
   private boolean myOnlySolveVars = false;
   private boolean myAllowEquations = true;
   private boolean myNormalize = true;
+  private boolean myComparingFunCalls = false;
   private Result myResult;
 
   public CompareVisitor(Equations equations, CMP cmp, Concrete.SourceNode sourceNode) {
@@ -207,6 +210,79 @@ public class CompareVisitor implements ExpressionVisitor2<Expression, Expression
     }
 
     return false;
+  }
+
+  private boolean compareFunCalls(FunCallExpression expr1, FunCallExpression expr2) {
+    if (myComparingFunCalls || expr1.getDefinition() != expr2.getDefinition() || expr1.getDefinition().isSFunc() ||
+        expr1.accept(FindInferenceVariablesVisitor.INSTANCE, null) || expr2.accept(FindInferenceVariablesVisitor.INSTANCE, null)) {
+      return false;
+    }
+
+    Result result = myResult;
+    CMP cmp = myCMP;
+    boolean ok;
+    myComparingFunCalls = true;
+    try {
+      myCMP = CMP.EQ;
+      ok = visitDefCall(expr1, expr2);
+    } finally {
+      myCMP = cmp;
+      myComparingFunCalls = false;
+    }
+    if (!ok) {
+      // The calls may still be equal after unfolding their common head.
+      myResult = result;
+    }
+    return ok;
+  }
+
+  private static class FindInferenceVariablesVisitor extends SearchVisitor<Void> {
+    private static final FindInferenceVariablesVisitor INSTANCE = new FindInferenceVariablesVisitor();
+
+    private static boolean hasInferenceVariable(Levels levels) {
+      for (Level level : levels.toList()) {
+        if (level.hasInferenceVariables()) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    private static boolean hasInferenceVariable(SortExpression sort) {
+      return switch (sort) {
+        case SortExpression.Const constant -> constant.sort().getPLevel().hasInferenceVariables();
+        case SortExpression.InfVar ignored -> true;
+        case SortExpression.Max max -> max.getSorts().stream().anyMatch(FindInferenceVariablesVisitor::hasInferenceVariable);
+        case SortExpression.Pi pi -> hasInferenceVariable(pi.getDomain()) || hasInferenceVariable(pi.getCodomain());
+        case SortExpression.Prev prev -> hasInferenceVariable(prev.getSort());
+        case SortExpression.Succ succ -> hasInferenceVariable(succ.getSort());
+        case SortExpression.Var ignored -> false;
+        case SortExpression.RecursiveData ignored -> false;
+      };
+    }
+
+    @Override
+    protected CoreExpression.FindAction processDefCall(DefCallExpression expression, Void param) {
+      return expression instanceof LeveledDefCallExpression leveled && hasInferenceVariable(leveled.getLevels())
+        ? CoreExpression.FindAction.STOP
+        : CoreExpression.FindAction.CONTINUE;
+    }
+
+    @Override
+    public Boolean visitInferenceReference(InferenceReferenceExpression expression, Void param) {
+      // A solved reference is unsafe as well: an outer rollback can make it unsolved again.
+      return true;
+    }
+
+    @Override
+    public Boolean visitUniverse(UniverseExpression expression, Void param) {
+      return hasInferenceVariable(expression.getSortExpression());
+    }
+
+    @Override
+    public Boolean visitTypeConstructor(TypeConstructorExpression expression, Void param) {
+      return hasInferenceVariable(expression.getLevels()) || super.visitTypeConstructor(expression, param);
+    }
   }
 
   private boolean initResult(Expression expr1, Expression expr2) {
@@ -463,6 +539,10 @@ public class CompareVisitor implements ExpressionVisitor2<Expression, Expression
         initResult(expr1, expr2);
         return false;
       }
+      return true;
+    }
+
+    if (expr1 instanceof FunCallExpression funCall1 && expr2 instanceof FunCallExpression funCall2 && compareFunCalls(funCall1, funCall2)) {
       return true;
     }
 

--- a/src/test/java/org/arend/term/expr/visitor/ComparisonTest.java
+++ b/src/test/java/org/arend/term/expr/visitor/ComparisonTest.java
@@ -2,21 +2,29 @@ package org.arend.term.expr.visitor;
 
 import org.arend.core.context.binding.Binding;
 import org.arend.core.context.binding.TypedBinding;
+import org.arend.core.context.binding.inference.ExpressionInferenceVariable;
 import org.arend.core.context.param.DependentLink;
 import org.arend.core.context.param.SingleDependentLink;
 import org.arend.core.definition.Definition;
 import org.arend.core.definition.FunctionDefinition;
 import org.arend.core.expr.DataCallExpression;
 import org.arend.core.expr.Expression;
+import org.arend.core.expr.InferenceReferenceExpression;
 import org.arend.core.expr.PiExpression;
+import org.arend.core.expr.visitor.CompareVisitor;
 import org.arend.core.expr.let.LetClause;
+import org.arend.core.sort.Level;
 import org.arend.core.subst.Levels;
 import org.arend.ext.core.ops.CMP;
+import org.arend.ext.error.ListErrorReporter;
 import org.arend.prelude.Prelude;
 import org.arend.server.ProgressReporter;
 import org.arend.typechecking.TypeCheckingTestCase;
 import org.arend.typechecking.computation.UnstoppableCancellationIndicator;
+import org.arend.typechecking.implicitargs.equations.Equations;
+import org.arend.typechecking.implicitargs.equations.TwoStageEquations;
 import org.arend.typechecking.result.TypecheckingResult;
+import org.arend.typechecking.visitor.CheckTypeVisitor;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -226,5 +234,114 @@ public class ComparisonTest extends TypeCheckingTestCase {
     TypecheckingResult result2 = typeCheckExpr("\\lam (p : \\Sigma) => ()", null);
     assertEquals(result2.expression, result1.expression);
     assertEquals(result1.expression, result2.expression);
+  }
+
+  @Test(timeout = 5000)
+  public void compareFunCallsBeforeHeadNormalization() {
+    typeCheckModule("\\func idType (A : \\Type) => A\n\\func loop (A : \\Type) => A");
+    FunctionDefinition idType = (FunctionDefinition) getDefinition("idType");
+    FunctionDefinition loop = (FunctionDefinition) getDefinition("loop");
+    DependentLink parameter = loop.getParameters();
+
+    // Normalizing either call diverges, but their arguments are equal after normalization.
+    loop.setBody(FunCall(loop, loop.makeMinLevels(), FunCall(idType, idType.makeMinLevels(), Ref(parameter))));
+    Expression expr1 = FunCall(loop, loop.makeMinLevels(), FunCall(idType, idType.makeMinLevels(), Universe(0)));
+    Expression expr2 = FunCall(loop, loop.makeMinLevels(), Universe(0));
+
+    assertTrue(compare(expr1, expr2, null, CMP.EQ));
+  }
+
+  @Test
+  public void compareFunCallsFallsBackToHeadNormalization() {
+    typeCheckModule("\\func constZero (n : Nat) => 0");
+    FunctionDefinition constZero = (FunctionDefinition) getDefinition("constZero");
+
+    assertTrue(compare(FunCall(constZero, Levels.EMPTY, Zero()), FunCall(constZero, Levels.EMPTY, Suc(Zero())), null, CMP.EQ));
+  }
+
+  @Test
+  public void compareFunCallsDetectsUnequalCalls() {
+    typeCheckModule("\\func idNat (n : Nat) => n");
+    FunctionDefinition idNat = (FunctionDefinition) getDefinition("idNat");
+
+    assertFalse(compare(FunCall(idNat, Levels.EMPTY, Zero()), FunCall(idNat, Levels.EMPTY, Suc(Zero())), null, CMP.EQ));
+  }
+
+  @Test
+  public void compareFunCallsDoesNotSolveInferenceVariable() {
+    typeCheckModule("\\func constZero (n : Nat) => 0");
+    FunctionDefinition constZero = (FunctionDefinition) getDefinition("constZero");
+    CheckTypeVisitor typechecker = new CheckTypeVisitor(new ListErrorReporter(), null, null);
+    Equations equations = typechecker.getEquations();
+    ExpressionInferenceVariable variable = new ExpressionInferenceVariable(Nat(), null, Collections.emptySet(), true);
+    Expression inferenceReference = InferenceReferenceExpression.make(variable, equations);
+
+    Expression expr1 = FunCall(constZero, Levels.EMPTY, inferenceReference);
+    Expression expr2 = FunCall(constZero, Levels.EMPTY, Suc(Zero()));
+
+    assertTrue(CompareVisitor.compare(equations, CMP.EQ, expr1, expr2, null, null));
+    assertFalse(variable.isSolved());
+    assertTrue(equations.solve(variable, Suc(Suc(Zero()))));
+  }
+
+  @Test
+  public void failedFunCallComparisonDoesNotLeakInferenceSolution() {
+    typeCheckModule("\\func constant2 (m n : Nat) => 0");
+    FunctionDefinition constant2 = (FunctionDefinition) getDefinition("constant2");
+    CheckTypeVisitor typechecker = new CheckTypeVisitor(new ListErrorReporter(), null, null);
+    Equations equations = typechecker.getEquations();
+    ExpressionInferenceVariable variable = new ExpressionInferenceVariable(Nat(), null, Collections.emptySet(), true);
+    Expression inferenceReference = InferenceReferenceExpression.make(variable, equations);
+
+    Expression expr1 = FunCall(constant2, Levels.EMPTY, inferenceReference, Zero());
+    Expression expr2 = FunCall(constant2, Levels.EMPTY, Suc(Zero()), Suc(Zero()));
+
+    assertTrue(CompareVisitor.compare(equations, CMP.EQ, expr1, expr2, null, null));
+    assertFalse(variable.isSolved());
+  }
+
+  @Test
+  public void compareFunCallsDoesNotAddLevelEquation() {
+    typeCheckModule("\\func constNat (A : \\Type) => 0");
+    FunctionDefinition constNat = (FunctionDefinition) getDefinition("constNat");
+    CheckTypeVisitor typechecker = new CheckTypeVisitor(new ListErrorReporter(), null, null);
+    int[] numberOfLevelEquations = new int[1];
+    TwoStageEquations equations = new TwoStageEquations(typechecker) {
+      @Override
+      public boolean addEquation(Level level1, Level level2, CMP cmp, org.arend.term.concrete.Concrete.SourceNode sourceNode) {
+        numberOfLevelEquations[0]++;
+        return super.addEquation(level1, level2, cmp, sourceNode);
+      }
+    };
+    Levels inferredLevels = constNat.generateInferVars(equations, null, false);
+
+    Expression expr1 = FunCall(constNat, inferredLevels, Universe(0));
+    Expression expr2 = FunCall(constNat, constNat.makeMinLevels(), Universe(0));
+
+    assertTrue(CompareVisitor.compare(equations, CMP.EQ, expr1, expr2, null, null));
+    assertEquals(0, numberOfLevelEquations[0]);
+  }
+
+  @Test
+  public void solvedInferenceReferenceRemainsSafeAfterRollback() {
+    typeCheckModule("\\func constZero (n : Nat) => 0");
+    FunctionDefinition constZero = (FunctionDefinition) getDefinition("constZero");
+    CheckTypeVisitor typechecker = new CheckTypeVisitor(new ListErrorReporter(), null, null);
+    Equations equations = typechecker.getEquations();
+    ExpressionInferenceVariable variable = new ExpressionInferenceVariable(Nat(), null, Collections.emptySet(), true);
+    Expression inferenceReference = InferenceReferenceExpression.make(variable, equations);
+    Expression expr1 = FunCall(constZero, Levels.EMPTY, inferenceReference);
+    Expression expr2 = FunCall(constZero, Levels.EMPTY, Suc(Zero()));
+
+    typechecker.withCurrentState(ignored -> {
+      assertTrue(equations.solve(variable, Suc(Zero())));
+      assertTrue(CompareVisitor.compare(equations, CMP.EQ, expr1, expr2, null, null));
+      typechecker.loadSavedState();
+      assertFalse(variable.isSolved());
+      return null;
+    });
+
+    assertTrue(CompareVisitor.compare(equations, CMP.EQ, expr1, expr2, null, null));
+    assertFalse(variable.isSolved());
   }
 }


### PR DESCRIPTION
In the `compare` function, add one more compare case — for the function calls. If both sides are functions, before normalizing the calls themselves, we are trying the case of "same functions — same normalized arguments"

### Example

```
f a \equiv f (id a)
```

With the new check, we will try to normalize and compare the arguments first. If they are equal, then we do not need to go further and can already say that they are equivalent.

### Why this matters

Usually, definitional equality is preserved by function application: if

```
a \equiv b
```

then we should also have

```
f a \equiv f b
```

There is no need to unfold f to establish this. It is enough to compare the arguments.

This is especially important for functions whose unfolding does not terminate or grows the expression. For example, suppose a function reduces as

```
f a = f (f a)
```

When comparing two calls headed by the same function, unfolding them first may lead the typechecker into an infinite reduction sequence. Comparing the function heads and their arguments before unfolding avoids this unnecessary normalization.

Besides preventing such loops, this also makes comparison cheaper in the common case: when two calls have the same function and equivalent arguments, the typechecker can establish their equivalence without inspecting the function body at all.
